### PR TITLE
Minor fix on benard-etal-2023-matos BibTex title

### DIFF
--- a/en/pages/publications.html
+++ b/en/pages/publications.html
@@ -309,7 +309,7 @@
 <br>
  <button type="button" class="btn btn-secondary btn-sm btn-pub-copy
  mt-3 mb-3 copyable" name="@inproceedings{benard-etal-2023-matos,
-      title = {{Translate your Own: a Post-Editing Experiment in the NLP domain]},
+      title = {{Translate your Own: a Post-Editing Experiment in the NLP domain}},
       author = {Rachel Bawden and Ziqian Peng and Maud Bénard and Villemonte de La Clergerie, Eric and Raphaël Esamotunu and Mathilde Huguin and Natalie Kübler and Alexandra Mestivier and Mona Michelot and Laurent Romary and Lichao Zhu and François Yvon},
       booktitle = {Proceedings of the 25th Annual Conference of the European Association for Machine Translation},
       year = {2024},

--- a/pages/publications.html
+++ b/pages/publications.html
@@ -315,7 +315,7 @@
 <br>
  <button type="button" class="btn btn-secondary btn-sm btn-pub-copy
  mt-3 mb-3 copyable" name="@inproceedings{benard-etal-2023-matos,
-     title = {{Translate your Own: a Post-Editing Experiment in the NLP domain]},
+     title = {{Translate your Own: a Post-Editing Experiment in the NLP domain}},
      author = {Rachel Bawden and Ziqian Peng and Maud Bénard and Villemonte de La Clergerie, Eric and Raphaël Esamotunu and Mathilde Huguin and Natalie Kübler and Alexandra Mestivier and Mona Michelot and Laurent Romary and Lichao Zhu and François Yvon},
      booktitle = {Proceedings of the 25th Annual Conference of the European Association for Machine Translation},
      year = {2024},


### PR DESCRIPTION
Minor fix on benard-etal-2023-matos title field, replace a closing square bracket by a curly one.